### PR TITLE
Proof commitment can contain null bytes

### DIFF
--- a/figment/api/ibc_mapper/ibc_channel.go
+++ b/figment/api/ibc_mapper/ibc_channel.go
@@ -1,6 +1,8 @@
 package mapper
 
 import (
+	"bytes"
+	"encoding/base64"
 	"fmt"
 	"strconv"
 
@@ -164,6 +166,15 @@ func IBCChannelRecvPacketToSub(msg []byte) (se shared.SubsetEvent, err error) {
 		return se, fmt.Errorf("Not a recv_packet type: %w", err)
 	}
 
+	// The proof_commitment field can contain null bytes. This data will end up getting written to postgres
+	// as a JSONB type. Postgres does not support null bytes in JSONB data types. In order to write this
+	// to the database while preserving the original value, encode it as base64.
+	proofCommitmentBuff := bytes.NewBuffer([]byte{})
+	b64Enc := base64.NewEncoder(base64.StdEncoding, proofCommitmentBuff)
+	if _, err := b64Enc.Write(m.ProofCommitment); err != nil {
+		return se, fmt.Errorf("Could not encode proof_commitment: %w", err)
+	}
+
 	return shared.SubsetEvent{
 		Type:   []string{"recv_packet"},
 		Module: "ibc",
@@ -180,7 +191,7 @@ func IBCChannelRecvPacketToSub(msg []byte) (se shared.SubsetEvent, err error) {
 			"packet_timeout_height_revision_number": {strconv.FormatUint(m.Packet.TimeoutHeight.RevisionNumber, 10)},
 			"packet_timeout_height_revision_height": {strconv.FormatUint(m.Packet.TimeoutHeight.RevisionHeight, 10)},
 			"packet_timeout_stamp":                  {strconv.FormatUint(m.Packet.TimeoutTimestamp, 10)},
-			"proof_commitment":                      {string(m.ProofCommitment)},
+			"proof_commitment":                      {proofCommitmentBuff.String()},
 			"proof_height_revision_number":          {strconv.FormatUint(m.ProofHeight.RevisionNumber, 10)},
 			"proof_height_revision_height":          {strconv.FormatUint(m.ProofHeight.RevisionHeight, 10)},
 		},

--- a/figment/api/ibc_mapper/ibc_channel_test.go
+++ b/figment/api/ibc_mapper/ibc_channel_test.go
@@ -1,0 +1,35 @@
+package mapper_test
+
+import (
+	"testing"
+
+	channel "github.com/cosmos/ibc-go/modules/core/04-channel/types"
+	mapper "github.com/figment-networks/ni-cosmoslib/figment/api/ibc_mapper"
+)
+
+func TestIBCChannelRecvPacketToSub(t *testing.T) {
+
+	// Just test that the proof commitment is actually being encoded as base64.
+	proofCommitment := "aa\u0000\u0000bb"
+	msg := channel.MsgRecvPacket{ProofCommitment: []byte(proofCommitment)}
+	bMsg, err := msg.Marshal()
+	if err != nil {
+		t.Errorf("unexpected marshal err: %s", err.Error())
+		return
+	}
+
+	subsetEvent, err := mapper.IBCChannelRecvPacketToSub(bMsg)
+	if err != nil {
+		t.Errorf("unexpected err: %s", err.Error())
+	}
+
+	value, ok := subsetEvent.Additional["proof_commitment"]
+	if !ok || len(value) == 0 {
+		t.Error("missing proof_commitment value")
+	}
+
+	expValue := "YWEAAGJi"
+	if value[0] != expValue {
+		t.Errorf("expected %s, received %s", expValue, value[0])
+	}
+}

--- a/figment/api/ibc_mapper/ibc_channel_test.go
+++ b/figment/api/ibc_mapper/ibc_channel_test.go
@@ -10,8 +10,8 @@ import (
 func TestIBCChannelRecvPacketToSub(t *testing.T) {
 
 	// Just test that the proof commitment is actually being encoded as base64.
-	proofCommitment := "aa\u0000\u0000bb"
-	msg := channel.MsgRecvPacket{ProofCommitment: []byte(proofCommitment)}
+	proofCommitment := []byte("aa\u0000\u0000bb")
+	msg := channel.MsgRecvPacket{ProofCommitment: proofCommitment}
 	bMsg, err := msg.Marshal()
 	if err != nil {
 		t.Errorf("unexpected marshal err: %s", err.Error())

--- a/figment/api/subevent.go
+++ b/figment/api/subevent.go
@@ -121,8 +121,8 @@ func AddIBCSubEvent(tev *structs.TransactionEvent, m *codec_types.Any, lg types.
 		return fmt.Errorf("problem with ibc event ibc event %s: %w", m.TypeUrl, ErrUnknownMessageType)
 	}
 
-	msgType := tPath[4]
-	msgRoute := tPath[2]
+	msgType := tPath[3]
+	msgRoute := tPath[1]
 
 	switch msgRoute {
 	case "client":

--- a/figment/api/subevent.go
+++ b/figment/api/subevent.go
@@ -121,8 +121,8 @@ func AddIBCSubEvent(tev *structs.TransactionEvent, m *codec_types.Any, lg types.
 		return fmt.Errorf("problem with ibc event ibc event %s: %w", m.TypeUrl, ErrUnknownMessageType)
 	}
 
-	msgType := tPath[3]
-	msgRoute := tPath[1]
+	msgType := tPath[4]
+	msgRoute := tPath[2]
 
 	switch msgRoute {
 	case "client":


### PR DESCRIPTION
I came across this while testing the crypto.org worker.  There is [this](https://crypto.org/explorer/block/2300098) block that contains an `IBC Recv Packet` transaction. This transaction has a field named [ProofCommitment](https://github.com/cosmos/ibc-go/blob/main/modules/core/04-channel/types/tx.pb.go#L519) that ends up getting encoded as JSON when it is saved to the database.

The problem is that this byte slice can contain null bytes, but postgres doesn't allow null bytes in JSONB type columns, so trying to write this transaction to the database currently results in a database error.  Encoding it as base64 allows the data to be preserved when it is written.