### PR TITLE
Encode proof fields to base64

### DIFF
--- a/figment/api/ibc_mapper/ibc_channel.go
+++ b/figment/api/ibc_mapper/ibc_channel.go
@@ -43,6 +43,12 @@ func IBCChannelOpenConfirmToSub(msg []byte) (se shared.SubsetEvent, err error) {
 		return se, fmt.Errorf("Not a channel_open_confirm type: %w", err)
 	}
 
+	// Encode fields that can contain null bytes.
+	proofAck, err := encodeToB64(m.ProofAck, "proof_ack")
+	if err != nil {
+		return se, err
+	}
+
 	return shared.SubsetEvent{
 		Type:   []string{"channel_open_confirm"},
 		Module: "ibc",
@@ -52,7 +58,7 @@ func IBCChannelOpenConfirmToSub(msg []byte) (se shared.SubsetEvent, err error) {
 		Additional: map[string][]string{
 			"port_id":                      {m.PortId},
 			"channel_id":                   {m.ChannelId},
-			"proof_ack":                    {string(m.ProofAck)},
+			"proof_ack":                    {proofAck},
 			"proof_height_revision_number": {strconv.FormatUint(m.ProofHeight.RevisionNumber, 10)},
 			"proof_height_revision_height": {strconv.FormatUint(m.ProofHeight.RevisionHeight, 10)},
 		},
@@ -66,6 +72,12 @@ func IBCChannelOpenAckToSub(msg []byte) (se shared.SubsetEvent, err error) {
 		return se, fmt.Errorf("Not a channel_open_ack type: %w", err)
 	}
 
+	// Encode fields that can contain null bytes.
+	proofTry, err := encodeToB64(m.ProofTry, "proof_try")
+	if err != nil {
+		return se, err
+	}
+
 	return shared.SubsetEvent{
 		Type:   []string{"channel_open_ack"},
 		Module: "ibc",
@@ -77,7 +89,7 @@ func IBCChannelOpenAckToSub(msg []byte) (se shared.SubsetEvent, err error) {
 			"channel_id":                   {m.ChannelId},
 			"counterparty_channel_id":      {m.CounterpartyChannelId},
 			"counterparty_version":         {m.CounterpartyVersion},
-			"proof_try":                    {string(m.ProofTry)},
+			"proof_try":                    {proofTry},
 			"proof_height_revision_number": {strconv.FormatUint(m.ProofHeight.RevisionNumber, 10)},
 			"proof_height_revision_height": {strconv.FormatUint(m.ProofHeight.RevisionHeight, 10)},
 		},
@@ -89,6 +101,12 @@ func IBCChannelOpenTryToSub(msg []byte) (se shared.SubsetEvent, err error) {
 	m := &channel.MsgChannelOpenTry{}
 	if err := proto.Unmarshal(msg, m); err != nil {
 		return se, fmt.Errorf("Not a channel_open_try type: %w", err)
+	}
+
+	// Encode fields that can contain null bytes.
+	proofInit, err := encodeToB64(m.ProofInit, "proof_init")
+	if err != nil {
+		return se, err
 	}
 
 	return shared.SubsetEvent{
@@ -107,7 +125,7 @@ func IBCChannelOpenTryToSub(msg []byte) (se shared.SubsetEvent, err error) {
 			"channel_connection_hops":         m.Channel.ConnectionHops,
 			"channel_version":                 {m.Channel.Version},
 			"counterparty_version":            {m.CounterpartyVersion},
-			"proof_init":                      {string(m.ProofInit)},
+			"proof_init":                      {proofInit},
 			"proof_height_revision_number":    {strconv.FormatUint(m.ProofHeight.RevisionNumber, 10)},
 			"proof_height_revision_height":    {strconv.FormatUint(m.ProofHeight.RevisionHeight, 10)},
 		},
@@ -141,6 +159,12 @@ func IBCChannelCloseConfirmToSub(msg []byte) (se shared.SubsetEvent, err error) 
 		return se, fmt.Errorf("Not a channel_close_confirm type: %w", err)
 	}
 
+	// Encode fields that can contain null bytes.
+	proofInit, err := encodeToB64(m.ProofInit, "proof_init")
+	if err != nil {
+		return se, err
+	}
+
 	return shared.SubsetEvent{
 		Type:   []string{"channel_close_confirm"},
 		Module: "ibc",
@@ -150,7 +174,7 @@ func IBCChannelCloseConfirmToSub(msg []byte) (se shared.SubsetEvent, err error) 
 		Additional: map[string][]string{
 			"port_id":                      {m.PortId},
 			"channel_id":                   {m.ChannelId},
-			"proof_init":                   {string(m.ProofInit)},
+			"proof_init":                   {proofInit},
 			"proof_height_revision_number": {strconv.FormatUint(m.ProofHeight.RevisionNumber, 10)},
 			"proof_height_revision_height": {strconv.FormatUint(m.ProofHeight.RevisionHeight, 10)},
 		},
@@ -200,6 +224,12 @@ func IBCChannelTimeoutToSub(msg []byte) (se shared.SubsetEvent, err error) {
 		return se, fmt.Errorf("Not a timeout type: %w", err)
 	}
 
+	// Encode fields that can contain null bytes.
+	proofUnreceived, err := encodeToB64(m.ProofUnreceived, "proof_unreceived")
+	if err != nil {
+		return se, err
+	}
+
 	return shared.SubsetEvent{
 		Type:   []string{"timeout"},
 		Module: "ibc",
@@ -216,7 +246,7 @@ func IBCChannelTimeoutToSub(msg []byte) (se shared.SubsetEvent, err error) {
 			"packet_timeout_height_revision_number": {strconv.FormatUint(m.Packet.TimeoutHeight.RevisionNumber, 10)},
 			"packet_timeout_height_revision_height": {strconv.FormatUint(m.Packet.TimeoutHeight.RevisionHeight, 10)},
 			"packet_timeout_stamp":                  {strconv.FormatUint(m.Packet.TimeoutTimestamp, 10)},
-			"proof_unreceived":                      {string(m.ProofUnreceived)},
+			"proof_unreceived":                      {proofUnreceived},
 			"proof_height_revision_number":          {strconv.FormatUint(m.ProofHeight.RevisionNumber, 10)},
 			"proof_height_revision_height":          {strconv.FormatUint(m.ProofHeight.RevisionHeight, 10)},
 			"next_sequence_recv":                    {strconv.FormatUint(m.NextSequenceRecv, 10)},

--- a/figment/api/ibc_mapper/ibc_client.go
+++ b/figment/api/ibc_mapper/ibc_client.go
@@ -57,6 +57,16 @@ func IBCUpgradeClientToSub(msg []byte) (se shared.SubsetEvent, err error) {
 		return se, fmt.Errorf("Not a upgrade_client type: %w", err)
 	}
 
+	// Encode fields that can contain null bytes.
+	proofUpgradeClient, err := encodeToB64(m.ProofUpgradeClient, "proof_upgrade_client")
+	if err != nil {
+		return se, err
+	}
+	proofUpgradeConsensusState, err := encodeToB64(m.ProofUpgradeConsensusState, "proof_upgrade_consensus_state")
+	if err != nil {
+		return se, err
+	}
+
 	return shared.SubsetEvent{
 		Type:   []string{"upgrade_client"},
 		Module: "ibc",
@@ -67,8 +77,8 @@ func IBCUpgradeClientToSub(msg []byte) (se shared.SubsetEvent, err error) {
 			"client_id":                     {m.ClientId},
 			"client_state":                  {m.ClientState.String()},
 			"consensus_state":               {m.ConsensusState.String()},
-			"proof_upgrade_client":          {string(m.ProofUpgradeClient)},
-			"proof_upgrade_consensus_state": {string(m.ProofUpgradeConsensusState)},
+			"proof_upgrade_client":          {proofUpgradeClient},
+			"proof_upgrade_consensus_state": {proofUpgradeConsensusState},
 		},
 	}, nil
 }

--- a/figment/api/ibc_mapper/ibc_connection.go
+++ b/figment/api/ibc_mapper/ibc_connection.go
@@ -42,6 +42,12 @@ func IBCConnectionOpenConfirmToSub(msg []byte) (se shared.SubsetEvent, err error
 		return se, fmt.Errorf("Not a connection_open_confirm type: %w", err)
 	}
 
+	// Encode fields that can contain null bytes.
+	proofAck, err := encodeToB64(m.ProofAck, "proof_ack")
+	if err != nil {
+		return se, err
+	}
+
 	return shared.SubsetEvent{
 		Type:   []string{"connection_open_confirm"},
 		Module: "ibc",
@@ -50,7 +56,7 @@ func IBCConnectionOpenConfirmToSub(msg []byte) (se shared.SubsetEvent, err error
 		},
 		Additional: map[string][]string{
 			"connection_id":                {m.ConnectionId},
-			"proof_ack":                    {string(m.ProofAck)},
+			"proof_ack":                    {proofAck},
 			"proof_height_revision_number": {strconv.FormatUint(m.ProofHeight.RevisionNumber, 10)},
 			"proof_height_revision_height": {strconv.FormatUint(m.ProofHeight.RevisionHeight, 10)},
 		},
@@ -62,6 +68,20 @@ func IBCConnectionOpenAckToSub(msg []byte) (se shared.SubsetEvent, err error) {
 	m := &connection.MsgConnectionOpenAck{}
 	if err := proto.Unmarshal(msg, m); err != nil {
 		return se, fmt.Errorf("Not a connection_open_ack type: %w", err)
+	}
+
+	// Encode fields that can contain null bytes.
+	proofTry, err := encodeToB64(m.ProofTry, "proof_try")
+	if err != nil {
+		return se, err
+	}
+	proofClient, err := encodeToB64(m.ProofClient, "proof_client")
+	if err != nil {
+		return se, err
+	}
+	proofConsensus, err := encodeToB64(m.ProofConsensus, "proof_consensus")
+	if err != nil {
+		return se, err
 	}
 
 	return shared.SubsetEvent{
@@ -78,9 +98,9 @@ func IBCConnectionOpenAckToSub(msg []byte) (se shared.SubsetEvent, err error) {
 			"client_state":                     {m.ClientState.String()},
 			"proof_height_revision_number":     {strconv.FormatUint(m.ProofHeight.RevisionNumber, 10)},
 			"proof_height_revision_height":     {strconv.FormatUint(m.ProofHeight.RevisionHeight, 10)},
-			"proof_try":                        {string(m.ProofTry)},
-			"proof_client":                     {string(m.ProofClient)},
-			"proof_consensus":                  {string(m.ProofConsensus)},
+			"proof_try":                        {proofTry},
+			"proof_client":                     {proofClient},
+			"proof_consensus":                  {proofConsensus},
 			"consensus_height_revision_number": {strconv.FormatUint(m.ConsensusHeight.RevisionNumber, 10)},
 			"consensus_height_revision_height": {strconv.FormatUint(m.ConsensusHeight.RevisionHeight, 10)},
 		},
@@ -92,6 +112,20 @@ func IBCConnectionOpenTryToSub(msg []byte) (se shared.SubsetEvent, err error) {
 	m := &connection.MsgConnectionOpenTry{}
 	if err := proto.Unmarshal(msg, m); err != nil {
 		return se, fmt.Errorf("Not a connection_open_try type: %w", err)
+	}
+
+	// Encode fields that can contain null bytes.
+	proofInit, err := encodeToB64(m.ProofInit, "proof_init")
+	if err != nil {
+		return se, err
+	}
+	proofClient, err := encodeToB64(m.ProofClient, "proof_client")
+	if err != nil {
+		return se, err
+	}
+	proofConsensus, err := encodeToB64(m.ProofConsensus, "proof_consensus")
+	if err != nil {
+		return se, err
 	}
 
 	se = shared.SubsetEvent{
@@ -111,9 +145,9 @@ func IBCConnectionOpenTryToSub(msg []byte) (se shared.SubsetEvent, err error) {
 			"counterparty_versions":            {},
 			"proof_height_revision_number":     {strconv.FormatUint(m.ProofHeight.RevisionNumber, 10)},
 			"proof_height_revision_height":     {strconv.FormatUint(m.ProofHeight.RevisionHeight, 10)},
-			"proof_init":                       {string(m.ProofInit)},
-			"proof_client":                     {string(m.ProofClient)},
-			"proof_consensus":                  {string(m.ProofConsensus)},
+			"proof_init":                       {proofInit},
+			"proof_client":                     {proofClient},
+			"proof_consensus":                  {proofConsensus},
 			"consensus_height_revision_number": {strconv.FormatUint(m.ConsensusHeight.RevisionNumber, 10)},
 			"consensus_height_revision_height": {strconv.FormatUint(m.ConsensusHeight.RevisionHeight, 10)},
 		},


### PR DESCRIPTION
A bit of info about this from the notion ticket:

The issue is that the database is throwing an error when trying to save a transaction of type "ibc timeout".  The `proof_unreceived` field has null bytes in it.  This issue came up for a couple of other ibc transaction types in the past and the solution was to encode the string as base64.

It seems like the offending fields are consistently those with a prefix of `proof_` that are a slice of bytes.  The work done for this ticket will update remaining ibc transaction types with these kinds of fields so that their contents are encoded to a base64 string. 