### PR TITLE
Use tag api/v0.1.4

### DIFF
--- a/ibcmapper/go.mod
+++ b/ibcmapper/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.45.4
 	github.com/cosmos/ibc-go v1.4.0
 	github.com/figment-networks/indexing-engine v0.9.17
-	github.com/figment-networks/ni-cosmoslib/api v0.1.4-0.20220518212026-ab96c3a41935
+	github.com/figment-networks/ni-cosmoslib/api v0.1.4
 	github.com/gogo/protobuf v1.3.3
 )
 

--- a/ibcmapper/go.sum
+++ b/ibcmapper/go.sum
@@ -302,8 +302,8 @@ github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8S
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/figment-networks/indexing-engine v0.9.17 h1:luUM3KixcwD6U+1/Q9tvaCoBPt+b1HXx5pPySu6aNGw=
 github.com/figment-networks/indexing-engine v0.9.17/go.mod h1:t7s24ZW7BR1trFxK4EKYwU/xGCg1/G5n5Vvt5xy8nG8=
-github.com/figment-networks/ni-cosmoslib/api v0.1.4-0.20220518212026-ab96c3a41935 h1:WKHzio8dLIwjeME6GTNVoDFkEE+O90XkqsTGzQgplMc=
-github.com/figment-networks/ni-cosmoslib/api v0.1.4-0.20220518212026-ab96c3a41935/go.mod h1:sxXDM3uFQ2xj1lbtOP/TWiNTlnLTHhjKcaqnCtLeDSs=
+github.com/figment-networks/ni-cosmoslib/api v0.1.4 h1:by1zYD79D5tW57G8q+TR2atJehdVaGL8o25IfgIDLjs=
+github.com/figment-networks/ni-cosmoslib/api v0.1.4/go.mod h1:9HmypxCCsPUzctOytFkpGpR12NLP7xJk0fF0aVNIbQ0=
 github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=

--- a/ibcmapper/v2/go.mod
+++ b/ibcmapper/v2/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.45.4
 	github.com/cosmos/ibc-go/v2 v2.2.0
 	github.com/figment-networks/indexing-engine v0.9.17
-	github.com/figment-networks/ni-cosmoslib/api v0.1.4-0.20220518212026-ab96c3a41935
+	github.com/figment-networks/ni-cosmoslib/api v0.1.4
 	github.com/gogo/protobuf v1.3.3
 )
 

--- a/ibcmapper/v2/go.sum
+++ b/ibcmapper/v2/go.sum
@@ -302,8 +302,8 @@ github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8S
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/figment-networks/indexing-engine v0.9.17 h1:luUM3KixcwD6U+1/Q9tvaCoBPt+b1HXx5pPySu6aNGw=
 github.com/figment-networks/indexing-engine v0.9.17/go.mod h1:t7s24ZW7BR1trFxK4EKYwU/xGCg1/G5n5Vvt5xy8nG8=
-github.com/figment-networks/ni-cosmoslib/api v0.1.4-0.20220518212026-ab96c3a41935 h1:WKHzio8dLIwjeME6GTNVoDFkEE+O90XkqsTGzQgplMc=
-github.com/figment-networks/ni-cosmoslib/api v0.1.4-0.20220518212026-ab96c3a41935/go.mod h1:sxXDM3uFQ2xj1lbtOP/TWiNTlnLTHhjKcaqnCtLeDSs=
+github.com/figment-networks/ni-cosmoslib/api v0.1.4 h1:by1zYD79D5tW57G8q+TR2atJehdVaGL8o25IfgIDLjs=
+github.com/figment-networks/ni-cosmoslib/api v0.1.4/go.mod h1:9HmypxCCsPUzctOytFkpGpR12NLP7xJk0fF0aVNIbQ0=
 github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=


### PR DESCRIPTION
Move to https://github.com/figment-networks/ni-cosmoslib/releases/tag/api%2Fv0.1.4 (tagged version) for api/util lib.