### PR TITLE
Error if no accounts

### DIFF
--- a/flow/rewards/rewards.go
+++ b/flow/rewards/rewards.go
@@ -251,6 +251,9 @@ func (re *RewardsExtraction) CalculateRewards(ctx context.Context, height, seque
 		if err != nil {
 			return fmt.Errorf("Error fetching initial accounts: %w", err)
 		}
+		if len(acc) == 0 {
+			return errors.New("no accounts found during fetch initial accounts")
+		}
 		b, err := json.Marshal(AccountsHeight{Accounts: acc, Height: height, Sequence: sequence})
 		if err != nil {
 			return err


### PR DESCRIPTION
It is possible that we do not get any accounts from the node.  An example of this is cosmos hub before vega..

If that happens, we will not have a good account list to fetch earned rewards.  (claimed rewards aren't affected)..

This PR will intends to handle this case as an error condition...

