### PR TITLE
Handle hang on no accounts

### DIFF
--- a/flow/rewards/rewards.go
+++ b/flow/rewards/rewards.go
@@ -443,6 +443,14 @@ func (re *RewardsExtraction) fetchHeightData(ctx context.Context, heights chan H
 }
 
 func (re *RewardsExtraction) fetchHeightUnclaimedRewards(ctx context.Context, height, sequence uint64, accounts map[string]interface{}) (newdelegs *rewstruct.Delegators, err error) {
+	newdelegs = &rewstruct.Delegators{
+		Height:     height,
+		Delegators: make(map[string]*rewstruct.ValidatorsUnclaimed),
+	}
+	if len(accounts) == 0 {
+		return newdelegs, nil
+	}
+
 	processing := make(chan string, 100)
 	outp := make(chan DelegateResponse, 100)
 	defer close(outp)
@@ -456,11 +464,6 @@ func (re *RewardsExtraction) fetchHeightUnclaimedRewards(ctx context.Context, he
 	// it's simpler than locking, counters or whatever.
 	// so below we always expect len(accounts) replies
 	go populateAccounts(processing, accounts)
-
-	newdelegs = &rewstruct.Delegators{
-		Height:     height,
-		Delegators: make(map[string]*rewstruct.ValidatorsUnclaimed),
-	}
 
 	var (
 		counter int


### PR DESCRIPTION
If the account list is empty we can hang here: https://github.com/figment-networks/ni-cosmoslib/blob/240bf11552d268dbc99bb17ee1d8bd96d27d3fc7/flow/rewards/rewards.go#L469

B/c the outp will never have anything and the range will just block.

To avoid this, only do work if the account list len > 0.