### PR TITLE
Fixed the unresolvable util version tags

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.45.4
 	github.com/figment-networks/indexing-engine v0.9.21
 	github.com/figment-networks/ni-cosmoslib/client v0.1.2
-	github.com/figment-networks/ni-cosmoslib/util v0.0.0-20220606143051-466af0576570
+	github.com/figment-networks/ni-cosmoslib/util v0.1.0
 	github.com/gogo/protobuf v1.3.3
 	github.com/gravity-devs/liquidity v1.4.2
 	go.uber.org/zap v1.19.1

--- a/api/go.sum
+++ b/api/go.sum
@@ -300,8 +300,8 @@ github.com/figment-networks/indexing-engine v0.9.21 h1:SBwMmCE4OC6K8PV2iyCkf3otG
 github.com/figment-networks/indexing-engine v0.9.21/go.mod h1:t7s24ZW7BR1trFxK4EKYwU/xGCg1/G5n5Vvt5xy8nG8=
 github.com/figment-networks/ni-cosmoslib/client v0.1.2 h1:Fuir+1nrp6e1GwmIuYqj6ok3eMVOS16jF47nHTrzfAQ=
 github.com/figment-networks/ni-cosmoslib/client v0.1.2/go.mod h1:dEgaZTUJAsL+E5GzIU7NxNIkhu/MVGFPkT3JI0+PCSs=
-github.com/figment-networks/ni-cosmoslib/util v0.0.0-20220606143051-466af0576570 h1:LZIUYzvwDDbGMwlVz6LvTxXLw8YYv8U9hOX0VVkSW4w=
-github.com/figment-networks/ni-cosmoslib/util v0.0.0-20220606143051-466af0576570/go.mod h1:+iFZ6mbgfQ+kzbcJpzHuDuATkb8HSvnegxymgAI9VOk=
+github.com/figment-networks/ni-cosmoslib/util v0.1.0 h1:q+def0heWWWit2D2cUDJg43gEsa5+Ce6fb3C6fW6uTc=
+github.com/figment-networks/ni-cosmoslib/util v0.1.0/go.mod h1:dL2Ix4BFUuEcxt+wu8rDhOqJrrYn2zfooUIRFWzr8uc=
 github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=

--- a/ibcmapper/go.mod
+++ b/ibcmapper/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.45.4
 	github.com/cosmos/ibc-go v1.4.0
 	github.com/figment-networks/indexing-engine v0.9.21
-	github.com/figment-networks/ni-cosmoslib/util v0.0.0-20220606143051-466af0576570
+	github.com/figment-networks/ni-cosmoslib/util v0.1.0
 	github.com/gogo/protobuf v1.3.3
 )
 

--- a/ibcmapper/go.sum
+++ b/ibcmapper/go.sum
@@ -290,8 +290,8 @@ github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8S
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/figment-networks/indexing-engine v0.9.21 h1:SBwMmCE4OC6K8PV2iyCkf3otG6sCXwvZP/tyHq9iPHM=
 github.com/figment-networks/indexing-engine v0.9.21/go.mod h1:t7s24ZW7BR1trFxK4EKYwU/xGCg1/G5n5Vvt5xy8nG8=
-github.com/figment-networks/ni-cosmoslib/util v0.0.0-20220606143051-466af0576570 h1:LZIUYzvwDDbGMwlVz6LvTxXLw8YYv8U9hOX0VVkSW4w=
-github.com/figment-networks/ni-cosmoslib/util v0.0.0-20220606143051-466af0576570/go.mod h1:+iFZ6mbgfQ+kzbcJpzHuDuATkb8HSvnegxymgAI9VOk=
+github.com/figment-networks/ni-cosmoslib/util v0.1.0 h1:q+def0heWWWit2D2cUDJg43gEsa5+Ce6fb3C6fW6uTc=
+github.com/figment-networks/ni-cosmoslib/util v0.1.0/go.mod h1:dL2Ix4BFUuEcxt+wu8rDhOqJrrYn2zfooUIRFWzr8uc=
 github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=

--- a/ibcmapper/v2/go.mod
+++ b/ibcmapper/v2/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.45.4
 	github.com/cosmos/ibc-go/v2 v2.2.0
 	github.com/figment-networks/indexing-engine v0.9.21
-	github.com/figment-networks/ni-cosmoslib/util v0.0.0-20220606143051-466af0576570
+	github.com/figment-networks/ni-cosmoslib/util v0.1.0
 	github.com/gogo/protobuf v1.3.3
 )
 

--- a/ibcmapper/v2/go.sum
+++ b/ibcmapper/v2/go.sum
@@ -290,8 +290,8 @@ github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8S
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/figment-networks/indexing-engine v0.9.21 h1:SBwMmCE4OC6K8PV2iyCkf3otG6sCXwvZP/tyHq9iPHM=
 github.com/figment-networks/indexing-engine v0.9.21/go.mod h1:t7s24ZW7BR1trFxK4EKYwU/xGCg1/G5n5Vvt5xy8nG8=
-github.com/figment-networks/ni-cosmoslib/util v0.0.0-20220606143051-466af0576570 h1:LZIUYzvwDDbGMwlVz6LvTxXLw8YYv8U9hOX0VVkSW4w=
-github.com/figment-networks/ni-cosmoslib/util v0.0.0-20220606143051-466af0576570/go.mod h1:+iFZ6mbgfQ+kzbcJpzHuDuATkb8HSvnegxymgAI9VOk=
+github.com/figment-networks/ni-cosmoslib/util v0.1.0 h1:q+def0heWWWit2D2cUDJg43gEsa5+Ce6fb3C6fW6uTc=
+github.com/figment-networks/ni-cosmoslib/util v0.1.0/go.mod h1:dL2Ix4BFUuEcxt+wu8rDhOqJrrYn2zfooUIRFWzr8uc=
 github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=

--- a/ibcmapper/v3/go.mod
+++ b/ibcmapper/v3/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.45.4
 	github.com/cosmos/ibc-go/v3 v3.0.0
 	github.com/figment-networks/indexing-engine v0.9.21
-	github.com/figment-networks/ni-cosmoslib/util v0.0.0-20220606143051-466af0576570
+	github.com/figment-networks/ni-cosmoslib/util v0.1.0
 	github.com/gogo/protobuf v1.3.3
 )
 

--- a/ibcmapper/v3/go.sum
+++ b/ibcmapper/v3/go.sum
@@ -252,8 +252,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/figment-networks/indexing-engine v0.9.21 h1:SBwMmCE4OC6K8PV2iyCkf3otG6sCXwvZP/tyHq9iPHM=
 github.com/figment-networks/indexing-engine v0.9.21/go.mod h1:t7s24ZW7BR1trFxK4EKYwU/xGCg1/G5n5Vvt5xy8nG8=
-github.com/figment-networks/ni-cosmoslib/util v0.0.0-20220606143051-466af0576570 h1:LZIUYzvwDDbGMwlVz6LvTxXLw8YYv8U9hOX0VVkSW4w=
-github.com/figment-networks/ni-cosmoslib/util v0.0.0-20220606143051-466af0576570/go.mod h1:+iFZ6mbgfQ+kzbcJpzHuDuATkb8HSvnegxymgAI9VOk=
+github.com/figment-networks/ni-cosmoslib/util v0.1.0 h1:q+def0heWWWit2D2cUDJg43gEsa5+Ce6fb3C6fW6uTc=
+github.com/figment-networks/ni-cosmoslib/util v0.1.0/go.mod h1:dL2Ix4BFUuEcxt+wu8rDhOqJrrYn2zfooUIRFWzr8uc=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=


### PR DESCRIPTION
I'm not sure how it was ever working to be honest -- `go get` wasn't able to resolve the version tag being used.